### PR TITLE
Fixed the badge image as we forgot to change the fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ECE5785 Lab 00
 This repository contains the lab 00 files for Semrah Odobasic and Mohammed Ayman Habib. <br />
 
-![example workflow](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/main.yml/badge.svg)
+![example workflow](https://github.com/AwsomeStar123456/ECE6785_Lab00/actions/workflows/main.yml/badge.svg)


### PR DESCRIPTION
For the given image we didn't change the repo the link was trying to go to. That is fixed with this branch.